### PR TITLE
Added GlobalMethodSecurity to enable Policies

### DIFF
--- a/bookshelf/src/main/kotlin/pt/unl/fct/di/iadidemo/bookshelf/config/SecurityConfig.kt
+++ b/bookshelf/src/main/kotlin/pt/unl/fct/di/iadidemo/bookshelf/config/SecurityConfig.kt
@@ -2,6 +2,7 @@ package pt.unl.fct.di.iadidemo.bookshelf.config
 
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
@@ -9,6 +10,7 @@ import org.springframework.security.web.authentication.www.BasicAuthenticationFi
 import pt.unl.fct.di.iadidemo.bookshelf.application.services.UserService
 
 @Configuration
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 class SecurityConfig(
     val customUserDetails:CustomUserDetailsService,
     val users: UserService


### PR DESCRIPTION
Added the annotation '@EnableGlobalMethodSecurity(prePostEnabled = true)' in [SecurityConfig.kt](https://github.com/IADI-FCT-NOVA/iadi-2021-assignment-6-companion/blob/main/bookshelf/src/main/kotlin/pt/unl/fct/di/iadidemo/bookshelf/config/SecurityConfig.kt) enable the usage of the security [Policies](https://github.com/IADI-FCT-NOVA/iadi-2021-assignment-6-companion/blob/main/bookshelf/src/main/kotlin/pt/unl/fct/di/iadidemo/bookshelf/config/Policies.kt)