### PR TITLE
Books pagination

### DIFF
--- a/bookshelf/src/main/kotlin/pt/unl/fct/di/iadidemo/bookshelf/BookShelfApplication.kt
+++ b/bookshelf/src/main/kotlin/pt/unl/fct/di/iadidemo/bookshelf/BookShelfApplication.kt
@@ -40,7 +40,17 @@ class SecurityApplication(
         val b2 = BookDAO(0,"Do Androids Dream of Electric Sheep?", mutableListOf(a1), listOf(ImageDAO(0, "https://covers.openlibrary.org/b/id/11153217-L.jpg")))
         val b3 = BookDAO(0,"The Man in the High Castle", mutableListOf(a1), listOf(ImageDAO(0, "https://covers.openlibrary.org/b/id/10045188-L.jpg")))
 
-        books.saveAll(listOf(b1,b2,b3))
+        val b4 = BookDAO(0,"Ubik", mutableListOf(a1), listOf(ImageDAO(0, "https://sm.ign.com/ign_br/screenshot/default/harry-potter-hbo-max_q8yn.jpg")))
+        val b5 = BookDAO(0,"Do Androids Dream of Electric Sheep?", mutableListOf(a1), listOf(ImageDAO(0, "https://exame.com/wp-content/uploads/2019/07/untitled-5-2.png")))
+        val b6 = BookDAO(0,"The Man in the High Castle", mutableListOf(a1), listOf(ImageDAO(0, "https://gkpb.com.br/wp-content/uploads/2021/12/gkpb-cinemark-reexibe-harry-potter.jpg")))
+
+        val b7 = BookDAO(0,"Ubik", mutableListOf(a1), listOf(ImageDAO(0, "https://static.globalnoticias.pt/dn/image.jpg?brand=DN&type=generate&guid=454e5789-8c37-4e1e-95b3-39529dad3740&w=800&h=450&t=20211117100639")))
+        val b8 = BookDAO(0,"Do Androids Dream of Electric Sheep?", mutableListOf(a1), listOf(ImageDAO(0, "https://t.ctcdn.com.br/w648g5hnt0u3-OvYjGE2l3OT0Fs=/512x288/smart/i525540.jpeg")))
+        val b9 = BookDAO(0,"The Man in the High Castle", mutableListOf(a1), listOf(ImageDAO(0, "https://sm.ign.com/t/ign_br/news/h/heres-our-/heres-our-first-look-at-harry-potter-20th-anniversary-return_8y39.620.jpg")))
+
+        val b10 = BookDAO(0,"The Man in the High Castle", mutableListOf(a1), listOf(ImageDAO(0, "https://sm.ign.com/t/ign_br/news/h/heres-our-/heres-our-first-look-at-harry-potter-20th-anniversary-return_8y39.620.jpg")))
+
+        books.saveAll(listOf(b1,b2,b3,b4,b5,b6,b7,b8,b9,b10))
     }
 
 }

--- a/bookshelf/src/main/kotlin/pt/unl/fct/di/iadidemo/bookshelf/application/services/AuthorService.kt
+++ b/bookshelf/src/main/kotlin/pt/unl/fct/di/iadidemo/bookshelf/application/services/AuthorService.kt
@@ -15,7 +15,7 @@ class AuthorService(val authors:AuthorRepository) {
 
     fun getAll(): List<AuthorDAO> = authors.findAll().toList()
 
-    fun addOne(author: AuthorDAO):Unit { authors.save(author) }
+    fun addOne(author: AuthorDAO):AuthorDAO = authors.save(author)
 
     fun getOne(id:Long):Optional<AuthorDAO> = authors.findById(id)
 

--- a/bookshelf/src/main/kotlin/pt/unl/fct/di/iadidemo/bookshelf/application/services/BookService.kt
+++ b/bookshelf/src/main/kotlin/pt/unl/fct/di/iadidemo/bookshelf/application/services/BookService.kt
@@ -1,5 +1,6 @@
 package pt.unl.fct.di.iadidemo.bookshelf.application.services
 
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import pt.unl.fct.di.iadidemo.bookshelf.application.services.exceptions.NoBookException
 import pt.unl.fct.di.iadidemo.bookshelf.domain.BookDAO
@@ -24,7 +25,7 @@ import java.util.*
 @Service
 class BookService(val books: BookRepository) {
 
-    fun getAll(): List<BookDAO> = books.findAll().toList()
+    fun getAll(page: Int, size: Int): List<BookDAO> = books.findAll(PageRequest.of(page,size)).toList()
 
     fun addOne(book: BookDAO): BookDAO = books.save(book)
 

--- a/bookshelf/src/main/kotlin/pt/unl/fct/di/iadidemo/bookshelf/config/Policies.kt
+++ b/bookshelf/src/main/kotlin/pt/unl/fct/di/iadidemo/bookshelf/config/Policies.kt
@@ -26,14 +26,14 @@ annotation class CanSeeAuthors {
 @PreAuthorize(CanAddBook.condition)
 annotation class CanAddBook {
     companion object {
-        const val condition:String = "hasRole('USER')"
+        const val condition:String = "hasRole('USER') or " + CanUpdateBook.condition
     }
 }
 
 @PreAuthorize(CanUpdateBook.condition)
 annotation class CanUpdateBook {
     companion object {
-        const val condition:String = "hasRole('REVIEWER')"
+        const val condition:String = "hasRole('REVIEWER') or " + CanDeleteBook.condition
     }
 }
 

--- a/bookshelf/src/main/kotlin/pt/unl/fct/di/iadidemo/bookshelf/domain/Repositories.kt
+++ b/bookshelf/src/main/kotlin/pt/unl/fct/di/iadidemo/bookshelf/domain/Repositories.kt
@@ -21,7 +21,7 @@ import org.springframework.data.repository.PagingAndSortingRepository
 
 interface UserRepository : PagingAndSortingRepository<UserDAO, String>
 
-interface BookRepository : CrudRepository<BookDAO, Long>
+interface BookRepository : PagingAndSortingRepository<BookDAO, Long>
 
 interface RoleRepository : CrudRepository<RoleDAO, String>
 

--- a/bookshelf/src/main/kotlin/pt/unl/fct/di/iadidemo/bookshelf/presentation/api/GenAPI.kt
+++ b/bookshelf/src/main/kotlin/pt/unl/fct/di/iadidemo/bookshelf/presentation/api/GenAPI.kt
@@ -4,7 +4,7 @@ import org.springframework.web.bind.annotation.*
 
 interface GenAPI<S,T,U> { // S - InDTO, T - ListDTO, U - LongDTO
     @GetMapping
-    fun getAll():List<T>;
+    fun getAll(@RequestParam(required = false, defaultValue = "0") page: Int, @RequestParam(required = false, defaultValue = "3") size: Int):List<T>
 
     @PostMapping
     fun addOne(@RequestBody elem:S): U

--- a/bookshelf/src/main/kotlin/pt/unl/fct/di/iadidemo/bookshelf/presentation/controllers/AuthorController.kt
+++ b/bookshelf/src/main/kotlin/pt/unl/fct/di/iadidemo/bookshelf/presentation/controllers/AuthorController.kt
@@ -26,16 +26,19 @@ import pt.unl.fct.di.iadidemo.bookshelf.presentation.api.dto.*
 class AuthorController(val authors: AuthorService) : AuthorAPI {
 
     @CanSeeAuthors
-    override fun getAll(): List<AuthorDTO> =
+    override fun getAll(page: Int, size: Int): List<AuthorDTO> =
         authors.getAll().map { AuthorDTO(
             it.id,
             it.name
         ) }
 
     @CanSeeAuthors
-    override fun addOne(elem: AuthorsBookDTO) {
+    override fun addOne(elem: AuthorsBookDTO): AuthorDTO =
         authors.addOne(AuthorDAO(0, elem.name))
-    }
+            .let { AuthorDTO(
+                it.id,
+                it.name
+            ) }
 
     @CanSeeAuthors
     override fun getOne(id: Long): AuthorDTO =
@@ -50,7 +53,7 @@ class AuthorController(val authors: AuthorService) : AuthorAPI {
             }
 
     @CanSeeAuthors
-    override fun updateOne(id: Long, elem: AuthorsBookDTO) {
+    override fun updateOne(id: Long, elem: AuthorsBookDTO):AuthorDTO {
         TODO("Not yet implemented")
     }
 

--- a/bookshelf/src/main/kotlin/pt/unl/fct/di/iadidemo/bookshelf/presentation/controllers/BookController.kt
+++ b/bookshelf/src/main/kotlin/pt/unl/fct/di/iadidemo/bookshelf/presentation/controllers/BookController.kt
@@ -28,8 +28,8 @@ import pt.unl.fct.di.iadidemo.bookshelf.presentation.api.dto.*
 class BookController(val books: BookService, val authors: AuthorService) : BooksAPI {
 
     @CanSeeBooks
-    override fun getAll(): List<BookListDTO> =
-        books.getAll().map {
+    override fun getAll(page: Int, size: Int): List<BookListDTO> =
+        books.getAll(page, size).map {
             BookListDTO(
                 it.id,
                 it.title,

--- a/bookshelf/src/test/kotlin/pt/unl/fct/di/iadidemo/bookshelf/BookControllerTests.kt
+++ b/bookshelf/src/test/kotlin/pt/unl/fct/di/iadidemo/bookshelf/BookControllerTests.kt
@@ -43,7 +43,7 @@ class BookControllerTests {
     @Test
     @WithMockUser(username = "user1", password = "password1", roles = ["USER"])
     fun `Test GET books`() {
-        Mockito.`when`(books.getAll()).thenReturn(l)
+        Mockito.`when`(books.getAll(0,3)).thenReturn(l)
 
         val s =
             mvc.perform(get("/user/books"))
@@ -55,7 +55,7 @@ class BookControllerTests {
     @Test
     @WithMockUser(username = "admin1", password = "password1", roles = ["ADMIN"])
     fun `Admin Test GET books`() {
-        Mockito.`when`(books.getAll()).thenReturn(l)
+        Mockito.`when`(books.getAll(0,3)).thenReturn(l)
 
         val s =
             mvc.perform(get("/admin/books"))


### PR DESCRIPTION
# Changes
- Implemented pagination for books, in order to retrieving portions of books (pages). Plus, added more books to our server, so we can test having more than 3 books
- Fixed policies regarding adding a book (all), editing a book (reviewer and admin), and deleting a book (only admin)